### PR TITLE
Overlap fix

### DIFF
--- a/css/posts.css
+++ b/css/posts.css
@@ -148,19 +148,19 @@ textarea {
 }
 
 @media only screen and (max-width: 767px) {
-    nav {
+    /* nav {
         height: 10vh;
         margin-left: 15px;
-    }
-    .bg-dark {
+    } */
+    /* .bg-dark {
         background-color: #6793b5!important;
-    }
+    } */
     #toggleBtn {
         background-color: #212529;
     }
-    #backToTopBtn {
+    /* #backToTopBtn {
         display: block;
-    }
+    } */
 
     .centerContainer {
         flex: 0 0 auto;

--- a/post.html
+++ b/post.html
@@ -36,7 +36,7 @@
                 <div class="col-2">
                     <div class="row fixed-top">
                         <div class="col" id="sidebarStuff">
-                            <nav class="navbar navbar-expand-md navbar-dark bg-dark d-flex flex-column">
+                            <nav class="fixed-top navbar navbar-expand-md navbar-dark bg-dark d-flex flex-column">
                                 <div class="container-fluid">
                                     <button id="toggleBtn" class="navbar-toggler" type="button"
                                         data-bs-toggle="offcanvas" data-bs-target="#offcanvasDarkNavbar"

--- a/profile.html
+++ b/profile.html
@@ -36,9 +36,8 @@
             <div class="row">
                 <!--=========================== Navbar: Left Side Content = =================================-->
                 <div class="col-2">
-                    <div class="row fixed-top">
                         <div class="col" id="sidebarStuff">
-                            <nav class="navbar navbar-expand-md navbar-dark bg-dark d-flex flex-column">
+                            <nav class="fixed-top navbar navbar-expand-md navbar-dark bg-dark d-flex flex-column">
                                 <div class="container-fluid">
                                     <button id="toggleBtn" class="navbar-toggler" type="button"
                                         data-bs-toggle="offcanvas" data-bs-target="#offcanvasDarkNavbar"
@@ -88,7 +87,6 @@
                                 </div>
                             </nav>
                         </div>
-                    </div>
                 </div>
 
                 <!--------------================================ -Center Content- =================================----------->


### PR DESCRIPTION
Previously at a width of 1023, my center container would not be responsive. Rather, The navbar was overlapping everything else. This fixes that issue.